### PR TITLE
Fix code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/tweet/common.js
+++ b/tweet/common.js
@@ -79,16 +79,28 @@ $(function(){
 	if (detect) update(detect);
 });
 
+var escapeHtml = function(text) {
+    var map = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#039;'
+    };
+    return text.replace(/[&<>"']/g, function(m) { return map[m]; });
+};
+
 var updateText = function(option){
-	$('#suggest').html('<select id="suggest-sel"><option value="">BlueHood トレンド</option></select>');
-	option.forEach(function(option, i){
-		var color = '#55acee';
-		$('#suggest-sel').append('<option value="'+option+'" style="color: '+color+'; ">'+option+'</option>');
-	});
-	$('#suggest-sel').change(function(){
-		var pos=$('#text').get(0).selectionStart;
-		var val=$('#text').val();
-		$('#text').val(val.substr(0,pos)+$(this).val()+val.substr(pos));
-		$('#text').keyup();
-	});
+    $('#suggest').html('<select id="suggest-sel"><option value="">BlueHood トレンド</option></select>');
+    option.forEach(function(option, i){
+        var color = '#55acee';
+        var escapedOption = escapeHtml(option);
+        $('#suggest-sel').append('<option value="'+escapedOption+'" style="color: '+color+'; ">'+escapedOption+'</option>');
+    });
+    $('#suggest-sel').change(function(){
+        var pos=$('#text').get(0).selectionStart;
+        var val=$('#text').val();
+        $('#text').val(val.substr(0,pos)+$(this).val()+val.substr(pos));
+        $('#text').keyup();
+    });
 };


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/bluehood-main/security/code-scanning/7](https://github.com/cooljeanius/bluehood-main/security/code-scanning/7)

To fix the problem, we need to ensure that the `option` values are properly escaped before being inserted into the HTML. This can be achieved by using a function to escape any HTML special characters in the `option` values. 

The best way to fix this without changing existing functionality is to create a utility function that escapes HTML special characters and use this function to sanitize the `option` values before appending them to the HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
