### PR TITLE
Fix code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/tweet/common.js
+++ b/tweet/common.js
@@ -57,7 +57,7 @@ var update = function(res){
 	}else{
 		//notice += "\nコミュニティに投稿されます。\n";
 	}
-	$('#title').html(title);
+	$('#title').html(escapeHtml(title));
 	if (res.msg){
 		//notice += res.msg;
 		alert(res.msg);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/bluehood-main/security/code-scanning/6](https://github.com/cooljeanius/bluehood-main/security/code-scanning/6)

To fix the problem, we need to ensure that any text inserted into the DOM is properly escaped to prevent XSS attacks. We can use the `escapeHtml` function to sanitize the `title` variable before it is inserted into the DOM.

- Identify the line where the `title` variable is inserted into the DOM (`$('#title').html(title);`).
- Use the `escapeHtml` function to sanitize the `title` variable before it is passed to the `html` method.
- Ensure that the `escapeHtml` function is correctly defined and available in the scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
