### PR TITLE
Fix code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/tweet/common.js
+++ b/tweet/common.js
@@ -40,8 +40,13 @@ $(function(){
 });
 
 var update = function(res){
-	thumb.setAttribute('src', 'data:image/jpeg;base64,' + res.image);
-	updateText(res.option);
+    if (isValidBase64(res.image)) {
+        thumb.setAttribute('src', 'data:image/jpeg;base64,' + res.image);
+    } else {
+        alert("Invalid image data.");
+        thumb.setAttribute('src', 'default-image.jpg'); // Use a default image or handle the error appropriately
+    }
+    updateText(res.option);
 
 	comm_ids = [];
 	var title = '';
@@ -103,4 +108,12 @@ var updateText = function(option){
         $('#text').val(val.substr(0,pos)+$(this).val()+val.substr(pos));
         $('#text').keyup();
     });
+};
+
+var isValidBase64 = function(str) {
+    try {
+        return btoa(atob(str)) === str;
+    } catch (err) {
+        return false;
+    }
 };


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/bluehood-main/security/code-scanning/5](https://github.com/cooljeanius/bluehood-main/security/code-scanning/5)

To fix the problem, we need to ensure that the `res.image` value is properly validated and sanitized before it is used. Since `res.image` is expected to be a base64-encoded string, we can validate that it conforms to the expected format. Additionally, we should ensure that any non-conforming input is either sanitized or rejected.

- Validate that `res.image` is a valid base64-encoded string.
- If the validation fails, handle the error appropriately (e.g., by displaying an error message or using a default image).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
